### PR TITLE
Add `type: module` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
+  "type": "module",
   "scripts": {
     "build": "rm -rf lib && tsc",
     "lint": "tslint -p tsconfig.json",


### PR DESCRIPTION
I was getting errors from sveltekit/vite without this.